### PR TITLE
Older git compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ function getEnvIdFromBranch () {
   try {
     let branch = sh.exec('git name-rev HEAD --name-only').stdout
 
+    branch = branch.split('/')
+
+    branch = branch[branch.length - 1]
+
     return _.trimEnd(_.truncate(branch, {
       length: 13,
       omission: ''

--- a/test/_env.js
+++ b/test/_env.js
@@ -6,9 +6,9 @@ const sh = require('shelljs')
 module.exports = function (regex) {
   var env = sh.exec('git name-rev HEAD --name-only').stdout
 
-env = env.split('/')
+  env = env.split('/')
 
-env = env[env.length - 1]
+  env = env[env.length - 1]
 
   return env ? _.truncate(env, {
     length: 13,

--- a/test/_env.js
+++ b/test/_env.js
@@ -6,6 +6,10 @@ const sh = require('shelljs')
 module.exports = function (regex) {
   var env = sh.exec('git name-rev HEAD --name-only').stdout
 
+env = env.split('/')
+
+env = env[env.length - 1]
+
   return env ? _.truncate(env, {
     length: 13,
     omission: ''


### PR DESCRIPTION
Found that on older git versions, it displayed name-rev like this: "remotes/origin/ci-prepare" grabbing only the branch name with this commit