### PR TITLE
Ability to read config.yml from the app root directory path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const head = require('lodash/fp/head')
 const pick = require('lodash/fp/pick')
 const keys = require('lodash/fp/keys')
 const fs = require('fs')
+const path = require('path')
 const sh = require('shelljs')
 const yaml = require('js-yaml')
 const moment = require('moment')
@@ -42,18 +43,22 @@ function loadConfigFile (file) {
 function loadConfig () {
   if (fs.existsSync('config.yml')) {
     return loadConfigFile('config.yml')
-  } else {
-    let templ = {}
-    multiFile = true
-    let files = fs.readdirSync('config')
-    for (let i = 0; i < files.length; i++) {
-      if (files[i].endsWith('.yml')) {
-        let keyName = files[i].substring(0, files[i].length - '.yml'.length)
-        templ[keyName] = loadConfigFile('config/' + files[i])
-      }
-    }
-    return templ
   }
+  let possibleAppRoot = path.join(__dirname, '..', '..', 'config.yml')
+  if (fs.existsSync(possibleAppRoot)) {
+    return loadConfigFile(possibleAppRoot)
+  }
+  let templ = {}
+  multiFile = true
+  let files = fs.readdirSync('config')
+  for (let i = 0; i < files.length; i++) {
+    if (files[i].endsWith('.yml')) {
+      let keyName = files[i].substring(0, files[i].length - '.yml'.length)
+      templ[keyName] = loadConfigFile('config/' + files[i])
+    }
+  }
+  return templ
+
 }
 
 function getEnvIdFromBranch () {


### PR DESCRIPTION
This PR allows to read `config.yml` from the application root path as a fallback location.

Example:
`node /path/to/main/script.js` will read `/path/to/main/config.yml` if the `config-yml` module was located in `/path/to/main/node_modules/config-yml`