### PR TITLE
Suppress output for git command

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function loadConfig () {
 
 function getEnvIdFromBranch () {
   try {
-    let branch = sh.exec('git name-rev HEAD --name-only').stdout
+    let branch = sh.exec('git name-rev HEAD --name-only', {silent: true}).stdout
 
     branch = _.last(_.split(branch, '/'))
 


### PR DESCRIPTION
Adds the `silent: true` option to the `sh.exec` call which is used to determine the currently active git branch.

This will address #15 

Thanks for your consideration and providing this helpful module!